### PR TITLE
fix: responsive mobile layout for song and playlist cards

### DIFF
--- a/frontend/src/components/PlaylistCard.css
+++ b/frontend/src/components/PlaylistCard.css
@@ -71,3 +71,39 @@
   color: #c89393;
   font-size: 0.95rem;
 }
+
+/* Responsive adjustments for tablets and mobile */
+@media (max-width: 768px) {
+  .playlist-card {
+    max-width: 100%;
+    padding: 14px 12px 12px 12px;
+    border-radius: 14px;
+  }
+
+  .playlist-title {
+    font-size: 1rem;
+  }
+
+  .playlist-count {
+    font-size: 0.88rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .playlist-card {
+    padding: 12px 10px 10px 10px;
+    border-radius: 12px;
+  }
+
+  .playlist-art-collage {
+    margin-bottom: 10px;
+  }
+
+  .playlist-title {
+    font-size: 0.95rem;
+  }
+
+  .playlist-count {
+    font-size: 0.85rem;
+  }
+}

--- a/frontend/src/components/SongCard.css
+++ b/frontend/src/components/SongCard.css
@@ -38,8 +38,8 @@
 /* Spotify-style song card grid */
 .song-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 28px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 24px;
   padding: 0 24px 24px 24px;
 }
 
@@ -100,4 +100,76 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.song-card-source {
+  color: #9a7878;
+  font-size: 0.85rem;
+  font-weight: 400;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Responsive adjustments for tablets and mobile */
+@media (max-width: 768px) {
+  .song-grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 16px;
+    padding: 0 16px 16px 16px;
+  }
+
+  .song-card-spotify {
+    padding: 14px 12px 12px 12px;
+    border-radius: 12px;
+  }
+
+  .song-card-title {
+    font-size: 0.95rem;
+  }
+
+  .song-card-artist {
+    font-size: 0.88rem;
+  }
+
+  .song-card-source {
+    font-size: 0.8rem;
+  }
+}
+
+/* Mobile-specific: optimized for small screens */
+@media (max-width: 480px) {
+  .song-grid {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px;
+    padding: 0 12px 12px 12px;
+  }
+
+  .song-card-spotify {
+    padding: 12px 10px 10px 10px;
+    border-radius: 10px;
+  }
+
+  .song-card-img-wrap {
+    border-radius: 10px;
+    margin-bottom: 10px;
+  }
+
+  .song-card-img {
+    border-radius: 10px;
+  }
+
+  .song-card-title {
+    font-size: 0.9rem;
+    margin-bottom: 1px;
+  }
+
+  .song-card-artist {
+    font-size: 0.82rem;
+  }
+
+  .song-card-source {
+    font-size: 0.75rem;
+  }
 }

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -117,7 +117,7 @@
 
 .song-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 24px;
   padding: 0 24px 24px 24px;
 }
@@ -183,5 +183,45 @@
   .search-results-dropdown {
     margin: 0 0.5rem;
     top: 44px;
+  }
+}
+
+/* Responsive grid for tablets and small screens */
+@media (max-width: 768px) {
+  .song-grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 16px;
+    padding: 0 16px 16px 16px;
+  }
+
+  .section-title {
+    margin: 24px 0 12px 16px;
+    font-size: 1.3rem;
+  }
+
+  .section-wrapper {
+    margin: 0 1rem;
+  }
+}
+
+/* Mobile-specific: Single column or 2-column grid for very small screens */
+@media (max-width: 480px) {
+  .song-grid {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px;
+    padding: 0 12px 12px 12px;
+  }
+
+  .section-title {
+    margin: 20px 0 10px 12px;
+    font-size: 1.2rem;
+  }
+
+  .section-wrapper {
+    margin: 0 0.5rem;
+  }
+
+  .home-page {
+    padding-bottom: 100px; /* More space for MiniPlayer on mobile */
   }
 }

--- a/frontend/src/pages/Library.css
+++ b/frontend/src/pages/Library.css
@@ -97,7 +97,7 @@
 
 .library-list {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 32px;
   padding: 32px 24px 0 24px;
   width: 100%;
@@ -283,11 +283,21 @@
     padding: 24px 0 0 0;
   }
   .library-list {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 20px;
     padding: 12px;
   }
   .library-card-img {
     min-width: 120px;
     max-width: 160px;
+  }
+}
+
+@media (max-width: 768px) {
+  .library-list {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 16px;
+    padding: 12px 16px;
   }
 }
 
@@ -300,7 +310,9 @@
     padding-right: 8px;
   }
   .library-list {
-    padding: 4px;
+    grid-template-columns: 1fr;
+    gap: 12px;
+    padding: 4px 12px;
   }
   .library-card {
     flex-direction: column;


### PR DESCRIPTION
- Change grid from auto-fill to auto-fit for better wrapping
- Add media queries for tablets (768px) and mobile (480px)
- Adjust card sizing and spacing for small screens
- Ensure single column layout on phones below 600px
- Fix overlapping cards and alignment issues


Hey! This PR fixes issue #2  Please add the hacktoberfest-accepted label if it fits 🙂